### PR TITLE
ci(node-install): bump setup-node & pnpm/action-setup to v6 (Node.js 24)

### DIFF
--- a/actions/node-install/action.yml
+++ b/actions/node-install/action.yml
@@ -9,10 +9,10 @@ runs:
   using: 'composite'
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version-file: package.json
         cache: pnpm


### PR DESCRIPTION
## What

Bump the two actions used by the `node-install` composite action off their Node.js 20 versions:

- `actions/setup-node@v4` → `@v6` (latest: v6.4.0)
- `pnpm/action-setup@v4` → `@v6` (latest: v6.0.9)

## Why

GitHub is retiring the Node.js 20 runner runtime. Both actions declared `runs.using: node20`, so every consuming repo's workflow logs a warning on each run:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/setup-node@v4, pnpm/action-setup@v4.

The v6 majors of both actions run natively on Node.js 24, which clears the warning fleet-wide (this action is consumed via `@master`, so every repo picks up the fix automatically once merged).

## Notes

- No input/behavior changes — the action still resolves the pnpm version from the `packageManager` field in `package.json` and the Node version from `node-version-file: package.json`.
- Consuming workflows already run on `ubuntu-24.04`, which provides the Node.js 24 runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)